### PR TITLE
Update sites.yml - added starter template repo

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -949,3 +949,12 @@
   date_created: 2024-11-12
   date_added: 2025-02-20
   repo_stars: 3328
+
+- title: sveltekit-shadcn-generic-template
+  url: https://ssv5.templates.guylahav.com
+  repo: https://github.com/GantonL/templates/tree/main/sveltekit-shadcn-v5
+  description: Simple, Powerful & Clean SvelteKit generic application starter template.
+  uses: [Typescript, Tailwind, shadcn-svelte, sveltekit-i18n, mdsvex, Cloudflare]
+  tags: [template, saas, blog, store, website, i18n, a11y]
+  date_created: 2025-07-13
+  date_added: 2025-08-03


### PR DESCRIPTION
Added a link to a generic-app-template repo. This is a small open-source project that helps me to kickstart new projects without the hustle of rewriting boring code every time. Such as i18n support and app structure, static content rendering with mdsvex, seo management, cookie management, legal pages (policies, a11y, etc.), base component like Shell, SEO, BasePage to abstract these things, theming and more. Adding new features and abstraction if they are generic enough. Hope this will help others to kickstart their projects faster.

New sites should be added to sites.yml, not the auto-generated readme. They should also be

- open source: While a site with private code can give design and feature ideas, there's little educational value if you can't inspect how it was made.
- novel: Not just another blog or todo app. Ideally, some application or technology not already covered in this collection.
- popular: At least 50 stars on GitHub or reasonable expectation to reach that number soon.

If you're unsure if a site belongs here, [open a discussion](https://github.com/janosh/awesome-sveltekit/discussions).

If your new site includes a tool/language/package in its `uses: [...]` field that's
not already used by another site, make sure you add a link to that tool in tools.yml.
